### PR TITLE
This is a change you may want to keep if you like.

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,5 +9,5 @@ permalink: /404.html
   <h1>Move along. (404 error)</h1>
   <br/>
 
-  <img src="{{ 'img/404-southpark.jpg' | relative_url }}" />
+  <img src="{{ 'https://s3.us-east-2.amazonaws.com/zachtankersley.com/Website_Object.jpg' | relative_url }}" />
 </div>

--- a/aboutme.md
+++ b/aboutme.md
@@ -4,7 +4,7 @@ title: About me
 subtitle: Why you'd want to go on a date with me
 ---
 
-My name is Inigo Montoya. I have the following qualities:
+My name Lord Zachary Tankersley, the 55th. I have the following qualities:
 
 - I rock a great mustache
 - I'm extremely loyal to my family


### PR DESCRIPTION
When visitors land on a page on your site that doesn't actually exist (say [https://zachtankersley.com/nilesh](https://zachtankersley.com/nilesh), your site should and does generate a 404 page.

This is also known as page not found error.

It had a southpark picture.

I swapped it out for a picture you might like and want to keep.

